### PR TITLE
parse sizes even without space between value and unit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,9 +118,10 @@ impl FromStr for Size {
     type Err = ParsingError;
 
     fn from_str(input: &str) -> Result<Size, Self::Err> {
-        let (index, _) = input.char_indices().find(|&(_, c)| !c.is_numeric()).ok_or(
-            ParsingError::MissingMultiple,
-        )?;
+        let (index, _) = input
+            .char_indices()
+            .find(|&(_, c)| !(c.is_numeric() || c == '.'))
+            .ok_or(ParsingError::MissingMultiple)?;
         let value_part = &input[0..index];
         if value_part.len() == 0 {
             return Err(ParsingError::MissingValue);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,19 +118,23 @@ impl FromStr for Size {
     type Err = ParsingError;
 
     fn from_str(input: &str) -> Result<Size, Self::Err> {
-        let mut parts = input.split_whitespace();
-        let value = parts.next().ok_or(ParsingError::MissingValue)?
-            .parse::<f64>().or_else(|_| Err(ParsingError::InvalidValue))?;
-        let multiple = parts.next().ok_or(ParsingError::MissingMultiple)?
-            .parse()?;
-
-        if parts.next().is_some() {
-            Err(ParsingError::UnknownExtra)
-        } else {
-            let size = Size::new(value, multiple)
-                .map_err(|_| ParsingError::InvalidValue)?;
-            Ok(size)
+        let (index, _) = input.char_indices().find(|&(_, c)| !c.is_numeric()).ok_or(
+            ParsingError::MissingMultiple,
+        )?;
+        let value_part = &input[0..index];
+        if value_part.len() == 0 {
+            return Err(ParsingError::MissingValue);
         }
+        let multiple_part = input[index..].trim();
+        let value = value_part.parse::<f64>().or_else(
+            |_| Err(ParsingError::InvalidValue),
+        )?;
+        let multiple = multiple_part.parse()?;
+
+        let size = Size::new(value, multiple).map_err(
+            |_| ParsingError::InvalidValue,
+        )?;
+        Ok(size)
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -27,9 +27,16 @@ fn should_parse_sizes() {
         //("12 ZiB", Ok(Size::new(12, Multiple::Zebibyte))),
         //("2 YiB", Ok(Size::new(2, Multiple::Yobibyte))),
 
-        ("", Err(ParsingError::MissingValue)),
+        ("12     MiB", Ok(Size::new(12, Multiple::Mebibyte))),
+        ("12\tMiB", Ok(Size::new(12, Multiple::Mebibyte))),
+        ("12MiB", Ok(Size::new(12, Multiple::Mebibyte))),
+        ("12MiB ", Ok(Size::new(12, Multiple::Mebibyte))),
+
+        ("", Err(ParsingError::MissingMultiple)),
+        ("MB", Err(ParsingError::MissingValue)),
+        ("10", Err(ParsingError::MissingMultiple)),
         ("10 abc", Err(ParsingError::InvalidMultiple)),
-        ("10 B EXTRA", Err(ParsingError::UnknownExtra)),
+        ("10 B EXTRA", Err(ParsingError::InvalidMultiple)),
     ];
 
     for test in tests {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -27,6 +27,10 @@ fn should_parse_sizes() {
         //("12 ZiB", Ok(Size::new(12, Multiple::Zebibyte))),
         //("2 YiB", Ok(Size::new(2, Multiple::Yobibyte))),
 
+        ("1.000 TB", Ok(Size::new(1, Multiple::Terabyte))),
+        ("1.2 TB", Ok(Size::new(1.2, Multiple::Terabyte))),
+        (".2 TB", Ok(Size::new(0.2, Multiple::Terabyte))),
+
         ("12     MiB", Ok(Size::new(12, Multiple::Mebibyte))),
         ("12\tMiB", Ok(Size::new(12, Multiple::Mebibyte))),
         ("12MiB", Ok(Size::new(12, Multiple::Mebibyte))),
@@ -36,6 +40,7 @@ fn should_parse_sizes() {
         ("MB", Err(ParsingError::MissingValue)),
         ("10", Err(ParsingError::MissingMultiple)),
         ("10 abc", Err(ParsingError::InvalidMultiple)),
+        (".B", Err(ParsingError::InvalidValue)),
         ("10 B EXTRA", Err(ParsingError::InvalidMultiple)),
     ];
 


### PR DESCRIPTION
Use case: parse the argument to a command line option: `--size=3KB`
Now, the accepted syntax should at least include:
`[1-9]+\w*[:unit:]\w*`
This changes the error values returned by parse:
* the empty string will return `InvalidMultiple` instead of `InvalidValue`
* `UnknownExtra` is now unused.
Since the precise semantics of the return value is not precisely defined in the doc, I guess this is fine.
I didn't remove the `UnknownExtra` enum member, though, since this would break the interface.