### PR TITLE
Rewrite the entire crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v0.4.0
 
 * **BREAKING**: Rewrote the entire module.
 * Added `SpecificSize`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+* **BREAKING**: Rewrote the entire module.
+* Added `SpecificSize`.
+* Added `Multiple` trait.
+* Added `multiples` module, contains implementations of the `Multiple` trait.
+* Added type alias `Size`, somewhat similar to the old `Size` of v0.3.
+
 # v0.3.0
 
 * **BREAKING**: Removed `UnknownExtra` variant from `ParsingError`, no longer used.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "human-size"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Thomas de Zeeuw <thomasdezeeuw@gmail.com>"]
 description = """
 Sizes for humans.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,24 @@ impl<M: Multiple> SpecificSize<M> {
     pub fn value(self) -> f64 {
         self.value
     }
+
+    /// Returns the multiple.
+    ///
+    /// ```
+    /// # extern crate human_size;
+    /// # fn main() {
+    /// use human_size::{SpecificSize, Any, Kilobyte};
+    ///
+    /// let size1 = SpecificSize::new(1, Kilobyte).unwrap();
+    /// let size2 = SpecificSize::new(1, Any::Kilobyte).unwrap();
+    ///
+    /// assert_eq!(size1.multiple(), Kilobyte);
+    /// assert_eq!(size2.multiple(), Any::Kilobyte);
+    /// # }
+    /// ```
+    pub fn multiple(self) -> M {
+        self.multiple
+    }
 }
 
 /// Check if the provided `value` is valid.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub type Size = SpecificSize<Any>;
 /// multiples, see the first example above. However due to a lack of precision
 /// in floating point numbers equality ignores a difference less then
 /// `0.00000001`, after applying the multiple. See the `PartialEq`
-/// implementation (via [src] to the right) for details.
+/// implementation (via \[src\] to the right) for details.
 ///
 /// [`FromStr`]: https://doc.rust-lang.org/nightly/core/str/trait.FromStr.html
 /// [`Multiple`]: trait.Multiple.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 Thomas de Zeeuw
+// Copyright 2017-2018 Thomas de Zeeuw
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,38 @@ impl<M: Multiple> SpecificSize<M> {
             Err(InvalidValueError)
         }
     }
+
+    /// Conversion between sizes with different multiples.
+    ///
+    /// This allows a size with one multiple to be converted into a size with
+    /// another multiple.
+    ///
+    /// ```
+    /// # extern crate human_size;
+    /// # fn main() {
+    /// use human_size::{SpecificSize, Byte, Kilobyte};
+    ///
+    /// let size = SpecificSize::new(1, Kilobyte).unwrap();
+    /// let size2: SpecificSize<Byte> = size.into();
+    ///
+    /// assert_eq!(size, size2);
+    /// assert_eq!(size.to_string(), "1 kB");
+    /// assert_eq!(size2.to_string(), "1000 B");
+    /// # }
+    /// ```
+    ///
+    /// # Notes
+    ///
+    /// Normally this would be done by implementing the `From` or `Into` trait.
+    /// However currently this is not possible due to the blanket implementation
+    /// in the standard library. Maybe once specialisation is available this can
+    /// be resolved.
+    pub fn into<M2>(self) -> SpecificSize<M2>
+        where M2: Multiple,
+    {
+        let (value, any) = M::into_any(self);
+        M2::from_any(value, any)
+    }
 }
 
 /// Check if the provided `value` is valid.
@@ -198,6 +230,16 @@ impl<M: Multiple> FromStr for SpecificSize<M> {
         }
     }
 }
+
+/*
+TODO: Needs specialisation.
+impl<M1: Multiple, M2: Multiple> From<SpecificSize<M2>> for SpecificSize<M1> {
+    fn from(size: SpecificSize<M2>) -> Self {
+        let (value, any) = M2::into_any(size);
+        M1::from_any(value, any)
+    }
+}
+*/
 
 /*
 TODO: Enable to specialisation for the same M.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,11 @@
 //! # fn main() {
 //! use human_size::{Size, SpecificSize, Kilobyte};
 //!
-//! let size1 = "10000 B".parse::<Size>().unwrap();
+//! let size1: Size = "10000 B".parse().unwrap();
 //! assert_eq!(size1.to_string(), "10000 B");
 //!
 //! // Or using a specific multiple.
-//! let size2 = "10000 B".parse::<SpecificSize<Kilobyte>>().unwrap();
+//! let size2: SpecificSize<Kilobyte> = "10000 B".parse().unwrap();
 //! assert_eq!(size2.to_string(), "10 kB");
 //!
 //! // Generic and specific sizes can be compared.
@@ -110,11 +110,14 @@ pub type Size = SpecificSize<Any>;
 ///
 /// # Notes
 ///
-/// When comparing sizes with one another it is possible compare different
+/// When comparing sizes with one another it is to possible compare different
 /// multiples, see the first example above. However due to a lack of precision
 /// in floating point numbers equality ignores a difference less then
 /// `0.00000001`, after applying the multiple. See the `PartialEq`
 /// implementation (via \[src\] to the right) for details.
+///
+/// The same is true for converting to and from multiples, here again the lack
+/// of precision of floating points can be cause of bugs.
 ///
 /// [`FromStr`]: https://doc.rust-lang.org/nightly/core/str/trait.FromStr.html
 /// [`Multiple`]: trait.Multiple.html
@@ -138,7 +141,7 @@ impl<M: Multiple> SpecificSize<M> {
     /// use human_size::{SpecificSize, Kilobyte, InvalidValueError};
     ///
     /// let size = SpecificSize::new(100, Kilobyte).unwrap();
-    /// println!("size: {}", size); // 100 kB
+    /// assert_eq!(size.to_string(), "100 kB");
     ///
     /// let res = SpecificSize::new(f64::NAN, Kilobyte);
     /// assert_eq!(res, Err(InvalidValueError)); // NAN is not a valid number.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,6 @@
         unused_results,
 )]
 
-// TODO: conversion to and from difference `Multiple`s.
-
-// TODO: implement serde.
-
 //! The `human_size` represents sizes for humans.
 //!
 //! The main type is [`SpecificSize`], which (as the name might suggests)
@@ -290,7 +286,7 @@ impl<M> PartialEq for SpecificSize<M> {
 
 /// The allowed margin to consider two floats still equal, after applying the
 /// multiple. Keep in sync with the Notes section of `SpecificSize`.
-const CMP_MARGIN: f64 = 0.00000001;
+const CMP_MARGIN: f64 = 0.000_000_01;
 
 impl<LM, RM> PartialEq<SpecificSize<RM>> for SpecificSize<LM>
     where LM: Multiple + Copy,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,6 @@ pub struct SpecificSize<M = Any> {
 }
 
 impl<M: Multiple> SpecificSize<M> {
-    // TODO: change print statements to assertions.
     /// Create a new `SpecificSize` with the given value and multiple. If the
     /// `value` is [not normal] this will return an error, however zero is
     /// allowed. If the `value` is normal the result can be safely unwraped.
@@ -198,7 +197,7 @@ impl<M: Multiple> FromStr for SpecificSize<M> {
 }
 
 /*
-TODO: enable to specialisation for the same M.
+TODO: Enable to specialisation for the same M.
 impl<M> PartialEq for SpecificSize<M> {
     fn eq(&self, other: &Self) -> bool {
         self.value == other.value
@@ -225,7 +224,7 @@ impl<LM, RM> PartialEq<SpecificSize<RM>> for SpecificSize<LM>
 }
 
 /*
-TODO: enable to specialisation for the same M.
+TODO: Enable to specialisation for the same M.
 impl<M> PartialOrd for SpecificSize<M> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.value.partial_cmp(&other.value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,7 @@ fn into_same_multiples<LM, RM>(left: SpecificSize<LM>, right: SpecificSize<RM>) 
 {
     let (left_value, left_multiple) = LM::into_any(left);
     let (right_value, right_multiple) = RM::into_any(right);
-    let multiply = left_multiple.multiple_of_bytes() as f64 / right_multiple.multiple_of_bytes() as f64;
+    let multiply = left_multiple.multiple_of_bytes() / right_multiple.multiple_of_bytes();
     (left_value * multiply, right_value)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,13 +136,13 @@ impl<M: Multiple> SpecificSize<M> {
     /// # extern crate human_size;
     /// # fn main() {
     /// use std::f64;
-    /// use human_size::{SpecificSize, Kilobyte};
+    /// use human_size::{SpecificSize, Kilobyte, InvalidValueError};
     ///
     /// let size = SpecificSize::new(100, Kilobyte).unwrap();
     /// println!("size: {}", size); // 100 kB
     ///
-    /// let size = SpecificSize::new(f64::NAN, Kilobyte);
-    /// println!("size is ok: {}", size.is_ok()); // false, NAN is not a valid number.
+    /// let res = SpecificSize::new(f64::NAN, Kilobyte);
+    /// assert_eq!(res, Err(InvalidValueError)); // NAN is not a valid number.
     /// # }
     /// ```
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! # Notes
 //!
 //! Internally `f64` is used to represent the size, so when comparing sizes with
-//! different multiples be weary of rounding errors related to usage of floating
+//! different multiples be wary of rounding errors related to usage of floating
 //! point numbers.
 
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,14 @@ pub mod multiples;
 
 pub use multiples::*;
 
-/// Size with a generic `Multiple`.
+/// Size with a generic [`Multiple`].
 ///
-/// Note that the size of `Size` is 16 bytes, but using a specific multiple,
-/// e.g. `SpecificSize<Byte>`, requires only 8 bytes.
+/// # Notes
+///
+/// The size of `Size` is 16 bytes, but using a specific multiple, e.g.
+/// `SpecificSize<Byte>`, requires only 8 bytes.
+///
+/// [`Multiple`]: trait.Multiple.html
 pub type Size = SpecificSize<Any>;
 
 /// `SpecificSize` represents a size in bytes with a multiple.
@@ -344,7 +348,9 @@ impl<M: fmt::Display> fmt::Display for SpecificSize<M> {
     }
 }
 
-/// Trait to convert a `SpecificSize` to and from different `Multiple`s.
+/// Trait to convert a [`SpecificSize`] to and from different multiples.
+///
+/// [`SpecificSize`]: struct.SpecificSize.html
 pub trait Multiple: Sized {
     /// Create a new [`SpecificSize`] from a `value` and `multiple`, the
     /// provided `value` must always valid (see [`SpecificSize::new`]).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,9 @@ impl<M: Multiple> SpecificSize<M> {
     /// ```
     ///
     /// [not normal]: https://doc.rust-lang.org/nightly/std/primitive.f64.html#method.is_normal
-    pub fn new<V: Into<f64>>(value: V, multiple: M) -> Result<SpecificSize<M>, InvalidValueError> {
+    pub fn new<V>(value: V, multiple: M) -> Result<SpecificSize<M>, InvalidValueError>
+        where V: Into<f64>,
+    {
         let value = value.into();
         if is_valid_value(value) {
             Ok(SpecificSize { value, multiple })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,22 @@ impl<M: Multiple> SpecificSize<M> {
         let (value, any) = M::into_any(self);
         M2::from_any(value, any)
     }
+
+    /// Returns the size in current the multiple.
+    ///
+    /// ```
+    /// # extern crate human_size;
+    /// # fn main() {
+    /// use human_size::{SpecificSize, Kilobyte};
+    ///
+    /// let size = SpecificSize::new(1, Kilobyte).unwrap();
+    ///
+    /// assert_eq!(size.value(), 1.0);
+    /// # }
+    /// ```
+    pub fn value(self) -> f64 {
+        self.value
+    }
 }
 
 /// Check if the provided `value` is valid.

--- a/src/multiples.rs
+++ b/src/multiples.rs
@@ -42,7 +42,7 @@ macro_rules! multiple {
 
         impl Multiple for $name {
             fn from_any(value: f64, multiple: Any) -> SpecificSize<Self> {
-                let multiply = multiple.multiple_of_bytes() / $size as f64;
+                let multiply = multiple.multiple_of_bytes() / $size;
                 let value = value * multiply;
                 SpecificSize { value, multiple: $name }
             }
@@ -54,27 +54,27 @@ macro_rules! multiple {
     };
 }
 
-multiple!(Byte, 1, "B");
+multiple!(Byte, 1f64, "B");
 
 // Multiples of 1000.
-multiple!(Kilobyte,  1000u128.pow(1), "kB");
-multiple!(Megabyte,  1000u128.pow(2), "MB");
-multiple!(Gigabyte,  1000u128.pow(3), "GB");
-multiple!(Terabyte,  1000u128.pow(4), "TB");
-multiple!(Petabyte,  1000u128.pow(5), "PB");
-multiple!(Exabyte,   1000u128.pow(6), "EB");
-multiple!(Zettabyte, 1000u128.pow(7), "ZB");
-multiple!(Yottabyte, 1000u128.pow(8), "YB");
+multiple!(Kilobyte,  1000f64.powi(1), "kB");
+multiple!(Megabyte,  1000f64.powi(2), "MB");
+multiple!(Gigabyte,  1000f64.powi(3), "GB");
+multiple!(Terabyte,  1000f64.powi(4), "TB");
+multiple!(Petabyte,  1000f64.powi(5), "PB");
+multiple!(Exabyte,   1000f64.powi(6), "EB");
+multiple!(Zettabyte, 1000f64.powi(7), "ZB");
+multiple!(Yottabyte, 1000f64.powi(8), "YB");
 
 // Multiples of 1024.
-multiple!(Kibibyte, 1024u128.pow(1), "KiB");
-multiple!(Mebibyte, 1024u128.pow(2), "MiB");
-multiple!(Gigibyte, 1024u128.pow(3), "GiB");
-multiple!(Tebibyte, 1024u128.pow(4), "TiB");
-multiple!(Pebibyte, 1024u128.pow(5), "PiB");
-multiple!(Exbibyte, 1024u128.pow(6), "EiB");
-multiple!(Zebibyte, 1024u128.pow(7), "ZiB");
-multiple!(Yobibyte, 1024u128.pow(8), "YiB");
+multiple!(Kibibyte, 1024f64.powi(1), "KiB");
+multiple!(Mebibyte, 1024f64.powi(2), "MiB");
+multiple!(Gigibyte, 1024f64.powi(3), "GiB");
+multiple!(Tebibyte, 1024f64.powi(4), "TiB");
+multiple!(Pebibyte, 1024f64.powi(5), "PiB");
+multiple!(Exbibyte, 1024f64.powi(6), "EiB");
+multiple!(Zebibyte, 1024f64.powi(7), "ZiB");
+multiple!(Yobibyte, 1024f64.powi(8), "YiB");
 
 /// A multiple which can represent all multiples.
 ///

--- a/src/multiples.rs
+++ b/src/multiples.rs
@@ -1,0 +1,209 @@
+// Copyright 2017-2018 Thomas de Zeeuw
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT
+// or http://opensource.org/licenses/MIT>, at your option. This file may not be
+// used, copied, modified, or distributed except according to those terms.
+
+//! Module containing all multiples.
+//!
+//! All types defined here implement [`Multiple`]. Because all types defined
+//! here, expect for `Any`, don't have any fields there size is always `0`.
+//! Meaning that for example `SpecificSize<Byte>` has the same size as `f64`
+//! (the type used as underlying value).
+//!
+//! [`Multiple`]: ../trait.Multiple.html
+
+use std::fmt;
+use std::str::FromStr;
+
+use super::{SpecificSize, ParsingError, Multiple};
+
+macro_rules! multiple {
+    ($name:ident, $size:expr, $str:expr) => {
+        multiple!($name, $size, $str, stringify!($name), stringify!($size));
+    };
+    ($name:ident, $size:expr, $str:expr, $sname:expr, $ssize:expr) => {
+        #[doc = "Multiple representing a "]
+        #[doc = $sname]
+        #[doc = "\n\nRepresents a size of `value *"]
+        #[doc = $ssize]
+        #[doc = "`. When parsing this multiple from text it expects `"]
+        #[doc = $str]
+        #[doc = "`."]
+        #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+        pub struct $name;
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.pad($str)
+            }
+        }
+
+        impl Multiple for $name {
+            fn from_any(value: f64, multiple: Any) -> SpecificSize<Self> {
+                let multiply = multiple.multiple_of_bytes() as f64 / $size as f64;
+                let value = value * multiply;
+                SpecificSize { value, multiple: $name }
+            }
+
+            fn into_any(size: SpecificSize<Self>) -> (f64, Any) {
+                (size.value, Any::$name)
+            }
+        }
+    };
+}
+
+multiple!(Byte, 1, "B");
+
+// Multiples of 1000.
+multiple!(Kilobyte,  1000u128.pow(1), "kB");
+multiple!(Megabyte,  1000u128.pow(2), "MB");
+multiple!(Gigabyte,  1000u128.pow(3), "GB");
+multiple!(Terabyte,  1000u128.pow(4), "TB");
+multiple!(Petabyte,  1000u128.pow(5), "PB");
+multiple!(Exabyte,   1000u128.pow(6), "EB");
+multiple!(Zettabyte, 1000u128.pow(7), "ZB");
+multiple!(Yottabyte, 1000u128.pow(8), "YB");
+
+// Multiples of 1024.
+multiple!(Kibibyte, 1024u128.pow(1), "KiB");
+multiple!(Mebibyte, 1024u128.pow(2), "MiB");
+multiple!(Gigibyte, 1024u128.pow(3), "GiB");
+multiple!(Tebibyte, 1024u128.pow(4), "TiB");
+multiple!(Pebibyte, 1024u128.pow(5), "PiB");
+multiple!(Exbibyte, 1024u128.pow(6), "EiB");
+multiple!(Zebibyte, 1024u128.pow(7), "ZiB");
+multiple!(Yobibyte, 1024u128.pow(8), "YiB");
+
+/// A multiple which can represent all multiples.
+///
+/// This is mainly used to parse a size from a string, but can also be used when
+/// you don't really care about the multiple or want to maintain the multiple
+/// from the parsed string.
+///
+/// For documentation of each variant see the equivalent struct in this module.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(missing_docs)]
+pub enum Any {
+    Byte,
+    Kilobyte,
+    Megabyte,
+    Gigabyte,
+    Terabyte,
+    Petabyte,
+    Exabyte,
+    Zettabyte,
+    Yottabyte,
+    Kibibyte,
+    Mebibyte,
+    Gigibyte,
+    Tebibyte,
+    Pebibyte,
+    Exbibyte,
+    Zebibyte,
+    Yobibyte,
+
+    /// This is not an actual `Multiple`, but allows the enum to be expanded in
+    /// the future without breaking match statements that try to match all
+    /// frame types, because that shouldn't be possible anymore.
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+impl Multiple for Any {
+    fn from_any(value: f64, multiple: Any) -> SpecificSize<Self> {
+        SpecificSize { value, multiple }
+    }
+
+    fn into_any(size: SpecificSize<Self>) -> (f64, Any) {
+        (size.value, size.multiple)
+    }
+}
+
+impl Any {
+    pub(crate) fn multiple_of_bytes(self) -> u128 {
+        match self {
+            Any::Byte => 1,
+
+            Any::Kilobyte =>  1000,
+            Any::Megabyte =>  1000u128.pow(2),
+            Any::Gigabyte =>  1000u128.pow(3),
+            Any::Terabyte =>  1000u128.pow(4),
+            Any::Petabyte =>  1000u128.pow(5),
+            Any::Exabyte =>   1000u128.pow(6),
+            Any::Zettabyte => 1000u128.pow(7),
+            Any::Yottabyte => 1000u128.pow(8),
+
+            Any::Kibibyte => 1024,
+            Any::Mebibyte => 1024u128.pow(2),
+            Any::Gigibyte => 1024u128.pow(3),
+            Any::Tebibyte => 1024u128.pow(4),
+            Any::Pebibyte => 1024u128.pow(5),
+            Any::Exbibyte => 1024u128.pow(6),
+            Any::Zebibyte => 1024u128.pow(7),
+            Any::Yobibyte => 1024u128.pow(8),
+
+            Any::__NonExhaustive => unreachable!(),
+        }
+    }
+}
+
+impl FromStr for Any {
+    type Err = ParsingError;
+
+    fn from_str(input: &str) -> Result<Any, Self::Err> {
+        match input {
+            "B" => Ok(Any::Byte),
+
+            "kB" => Ok(Any::Kilobyte),
+            "MB" => Ok(Any::Megabyte),
+            "GB" => Ok(Any::Gigabyte),
+            "TB" => Ok(Any::Terabyte),
+            "PB" => Ok(Any::Petabyte),
+            "EB" => Ok(Any::Exabyte),
+            "ZB" => Ok(Any::Zettabyte),
+            "YB" => Ok(Any::Yottabyte),
+
+            "KB" | "KiB" => Ok(Any::Kibibyte),
+            "MiB" => Ok(Any::Mebibyte),
+            "GiB" => Ok(Any::Gigibyte),
+            "TiB" => Ok(Any::Tebibyte),
+            "PiB" => Ok(Any::Pebibyte),
+            "EiB" => Ok(Any::Exbibyte),
+            "ZiB" => Ok(Any::Zebibyte),
+            "YiB" => Ok(Any::Yobibyte),
+
+            _ => Err(ParsingError::InvalidMultiple),
+        }
+    }
+}
+
+impl fmt::Display for Any {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let value = match *self {
+            Any::Byte => "B",
+
+            Any::Kilobyte => "kB",
+            Any::Megabyte => "MB",
+            Any::Gigabyte => "GB",
+            Any::Terabyte => "TB",
+            Any::Petabyte => "PB",
+            Any::Exabyte => "EB",
+            Any::Zettabyte => "ZB",
+            Any::Yottabyte => "YB",
+
+            Any::Kibibyte => "KiB",
+            Any::Mebibyte => "MiB",
+            Any::Gigibyte => "GiB",
+            Any::Tebibyte => "TiB",
+            Any::Pebibyte => "PiB",
+            Any::Exbibyte => "EiB",
+            Any::Zebibyte => "ZiB",
+            Any::Yobibyte => "YiB",
+
+            Any::__NonExhaustive => unreachable!(),
+        };
+        f.pad(value)
+    }
+}

--- a/src/multiples.rs
+++ b/src/multiples.rs
@@ -42,7 +42,7 @@ macro_rules! multiple {
 
         impl Multiple for $name {
             fn from_any(value: f64, multiple: Any) -> SpecificSize<Self> {
-                let multiply = multiple.multiple_of_bytes() as f64 / $size as f64;
+                let multiply = multiple.multiple_of_bytes() / $size as f64;
                 let value = value * multiply;
                 SpecificSize { value, multiple: $name }
             }
@@ -122,27 +122,27 @@ impl Multiple for Any {
 }
 
 impl Any {
-    pub(crate) fn multiple_of_bytes(self) -> u128 {
+    pub(crate) fn multiple_of_bytes(self) -> f64 {
         match self {
-            Any::Byte => 1,
+            Any::Byte => 1f64,
 
-            Any::Kilobyte =>  1000,
-            Any::Megabyte =>  1000u128.pow(2),
-            Any::Gigabyte =>  1000u128.pow(3),
-            Any::Terabyte =>  1000u128.pow(4),
-            Any::Petabyte =>  1000u128.pow(5),
-            Any::Exabyte =>   1000u128.pow(6),
-            Any::Zettabyte => 1000u128.pow(7),
-            Any::Yottabyte => 1000u128.pow(8),
+            Any::Kilobyte =>  1000f64,
+            Any::Megabyte =>  1000f64.powi(2),
+            Any::Gigabyte =>  1000f64.powi(3),
+            Any::Terabyte =>  1000f64.powi(4),
+            Any::Petabyte =>  1000f64.powi(5),
+            Any::Exabyte =>   1000f64.powi(6),
+            Any::Zettabyte => 1000f64.powi(7),
+            Any::Yottabyte => 1000f64.powi(8),
 
-            Any::Kibibyte => 1024,
-            Any::Mebibyte => 1024u128.pow(2),
-            Any::Gigibyte => 1024u128.pow(3),
-            Any::Tebibyte => 1024u128.pow(4),
-            Any::Pebibyte => 1024u128.pow(5),
-            Any::Exbibyte => 1024u128.pow(6),
-            Any::Zebibyte => 1024u128.pow(7),
-            Any::Yobibyte => 1024u128.pow(8),
+            Any::Kibibyte => 1024f64,
+            Any::Mebibyte => 1024f64.powi(2),
+            Any::Gigibyte => 1024f64.powi(3),
+            Any::Tebibyte => 1024f64.powi(4),
+            Any::Pebibyte => 1024f64.powi(5),
+            Any::Exbibyte => 1024f64.powi(6),
+            Any::Zebibyte => 1024f64.powi(7),
+            Any::Yobibyte => 1024f64.powi(8),
 
             Any::__NonExhaustive => unreachable!(),
         }

--- a/src/multiples.rs
+++ b/src/multiples.rs
@@ -106,7 +106,7 @@ pub enum Any {
 
     /// This is not an actual `Multiple`, but allows the enum to be expanded in
     /// the future without breaking match statements that try to match all
-    /// frame types, because that shouldn't be possible anymore.
+    /// types.
     #[doc(hidden)]
     __NonExhaustive,
 }

--- a/src/multiples.rs
+++ b/src/multiples.rs
@@ -19,6 +19,10 @@ use std::str::FromStr;
 
 use super::{SpecificSize, ParsingError, Multiple};
 
+/// Macro to create a multiple.
+///
+/// This multiple will be a zero sized struct that implements `Multiple` and
+/// `fmt::Display`.
 macro_rules! multiple {
     ($name:ident, $size:expr, $str:expr) => {
         multiple!($name, $size, $str, stringify!($name), stringify!($size));

--- a/src/multiples.rs
+++ b/src/multiples.rs
@@ -8,7 +8,7 @@
 //! Module containing all multiples.
 //!
 //! All types defined here implement [`Multiple`]. Because all types defined
-//! here, expect for `Any`, don't have any fields there size is always `0`.
+//! here, expect for `Any`, don't have any fields they are always zero sized.
 //! Meaning that for example `SpecificSize<Byte>` has the same size as `f64`
 //! (the type used as underlying value).
 //!
@@ -111,6 +111,8 @@ pub enum Any {
     /// This is not an actual `Multiple`, but allows the enum to be expanded in
     /// the future without breaking match statements that try to match all
     /// types.
+    ///
+    /// TODO: replace it with the `non_exhaustive` attribute.
     #[doc(hidden)]
     __NonExhaustive,
 }

--- a/src/multiples.rs
+++ b/src/multiples.rs
@@ -55,6 +55,12 @@ macro_rules! multiple {
                 (size.value, Any::$name)
             }
         }
+
+        impl From<$name> for Any {
+            fn from(_multiple: $name) -> Any {
+                Any::$name
+            }
+        }
     };
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -49,6 +49,7 @@ macro_rules! parse_test {
 #[test]
 fn simple_size_parsing() {
     parse_test!("0 B", 0, Byte);
+    parse_test!("0B", 0, Byte);
 
     // Multiples of 1000.
     parse_test!("1.0 kB", 1, Kilobyte);
@@ -63,6 +64,7 @@ fn simple_size_parsing() {
     // Multiples of 1024.
     parse_test!("0.0 KB", 0, Kibibyte);
     parse_test!("1. KiB", 1, Kibibyte);
+    parse_test!("1.KiB", 1, Kibibyte);
     parse_test!("100 MiB", 100, Mebibyte);
     parse_test!("100 GiB", 100, Gigibyte);
     parse_test!("123 TiB", 123, Tebibyte);
@@ -77,6 +79,7 @@ fn simple_size_parsing() {
     parse_test!("1.0 kB", 1, Any::Kilobyte);
     parse_test!("123.0 MB", 123, Any::Megabyte);
     parse_test!("100 GB", 100, Any::Gigabyte);
+    parse_test!("100GB", 100, Any::Gigabyte);
     parse_test!("321 TB", 321, Any::Terabyte);
     parse_test!("10 PB", 10, Any::Petabyte);
     parse_test!("12 EB", 12, Any::Exabyte);
@@ -117,16 +120,15 @@ fn size_parsing_errors() {
     parse_test!("", ParsingError::EmptyInput);
 
     parse_test!("B", ParsingError::MissingValue);
+    parse_test!("abc MB", ParsingError::MissingValue); // TODO: InvalidValue would be better.
 
-    parse_test!("abc MG", ParsingError::InvalidValue);
-    parse_test!("1.0.0 MB", ParsingError::InvalidValue);
+    parse_test!("1.0.0 GB", ParsingError::InvalidValue);
     parse_test!(". B", ParsingError::InvalidValue);
 
     parse_test!("10", ParsingError::MissingMultiple);
 
     parse_test!("10 abc", ParsingError::InvalidMultiple);
-
-    parse_test!("10 B extra", ParsingError::UnknownExtra);
+    parse_test!("10 B extra", ParsingError::InvalidMultiple);
 }
 
 /// Create a new display test.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -96,7 +96,7 @@ fn simple_size_parsing() {
     parse_test!("1 ZiB", 1, Any::Zebibyte);
     parse_test!("2 YiB", 2, Any::Yobibyte);
 
-    // Accept some extra whitespace.
+    // Accept some extra white space.
     parse_test!("   100   B   ", 100, Byte);
     parse_test!("12   MiB   ", 12, Mebibyte);
     parse_test!(" \t\t 100 \n\n  B \n  ", 100, Byte);
@@ -277,4 +277,20 @@ fn ordering_tests() {
 
     ordering_test!(1, Kibibyte, Greater, 1, Kilobyte);
     ordering_test!(1, Kilobyte, Less, 1, Kibibyte);
+}
+
+macro_rules! into_test {
+    ($size_left:expr, $type_left:expr, $size_right:expr, $type_right:expr, $tr:ty) => {
+        let left = SpecificSize::new($size_left, $type_left).unwrap();
+        let converted = left.into::<$tr>();
+        let right = SpecificSize::new($size_right, $type_right).unwrap();
+        assert_eq!(converted, right);
+    };
+}
+
+#[test]
+fn into_tests() {
+    into_test!(1, Byte, 0.001, Kilobyte, Kilobyte);
+    into_test!(1000, Byte, 1, Kilobyte, Kilobyte);
+    into_test!(1000, Byte, 1, Kilobyte, Kilobyte);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -112,7 +112,7 @@ fn parsing_size_conversion() {
     // This is where floats lose there precision.
     parse_test!("100 MiB", 104.85759999999999, Megabyte);
 
-    // TODO: Add more conversioon tests.
+    // TODO: Add more conversion tests.
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,10 @@
+// Copyright 2017-2018 Thomas de Zeeuw
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT
+// or http://opensource.org/licenses/MIT>, at your option. This file may not be
+// used, copied, modified, or distributed except according to those terms.
+
 extern crate human_size;
 
 use human_size::*;


### PR DESCRIPTION
TODO:
- [x] Conversion to and from specific sizes, e.g. `SpecificSize<Byte>` to `SpecificSize<Kilobyte>`.