### PR TITLE
Implementation of `Eq` on `SpecificSize<M>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.4.3
+
+* Added `Eq` implementation to `SpecificSize`.
+
 # v0.4.2
 
 * Added `SpecificSize::to_bytes`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "human-size"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Thomas de Zeeuw <thomasdezeeuw@gmail.com>"]
 description = """
 Sizes for humans.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,8 @@ where
     }
 }
 
+impl<M> Eq for SpecificSize<M> where M: Multiple + Copy {}
+
 /*
 TODO: Enable to specialisation for the same M.
 impl<M> PartialOrd for SpecificSize<M> {


### PR DESCRIPTION
This PR adds `Eq` implementation to `SpecificSize<M>`. Reason for this is that `[serde(default)]` attribute require type to be `Eq` (for whatever reason, idk). IMO this implementation shouldn't break anything and actually should be present, since `PartialEq` on `SpecificSize` adhere to `Eq` [rules](https://doc.rust-lang.org/std/cmp/trait.Eq.html).

I also bumped version, since there is no another unreleased code, but if this is wrong I can remove it.